### PR TITLE
Fix reorder and delete

### DIFF
--- a/app/tokens.js
+++ b/app/tokens.js
@@ -43,9 +43,9 @@ AuthToken.prototype.writeToken = function(tokens) {
   return this.file;
 }
 
-AuthToken.prototype.deleteToken = function(token) {
+AuthToken.prototype.deleteToken = function(tokenNames) {
   for (let i in this.file.data) {
-    if(this.file.data[i]["name"] === token) {
+    if(tokenNames.indexOf(this.file.data[i]["name"]) != -1) {
       this.file.data.splice(i, 1);
     }
   }

--- a/app/tokens.js
+++ b/app/tokens.js
@@ -26,9 +26,10 @@ AuthToken.prototype.reorderTokens = function(tokens) {
   for (let name of newOrder) {
     newTokens.data.push(this.file.data[fileOrder.indexOf(name)]);
   }
-  fs.writeFileSync(FILE_NAME, newTokens, "cbor");
-  return newTokens;
-}  
+  this.file = newTokens;
+  fs.writeFileSync(FILE_NAME, this.file, "cbor");
+  return this.file;
+}
 
 AuthToken.prototype.writeToken = function(tokens) {
   tokens = JSON.parse(JSON.stringify(tokens)); //hasOwnProperty does not function correctly without this re-parse

--- a/companion/settings.js
+++ b/companion/settings.js
@@ -31,7 +31,7 @@ export function deleteItem(oldVal,newVal) {
       return newNames.indexOf(i) < 0;
     });
   }
-  return deleteArr;
+  return {"delete": deleteArr};
 }
 
 export function checkUniqueNames(newArray) {


### PR DESCRIPTION
This fixes the problem where reordering a list of tokens works initially, but reverts to the previous order the next time tokens are generated (until the app is closed and relaunched).

Also fix the problem where deleting tokens in the settings didn't delete them from the watch until the remaining tokens in the list were reordered in the settings.
