### PR TITLE
Fix build for Versa 2 on SDK 4.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ For a list of all changes please click [here](CHANGELOG.md).
 - Fitbit example project [sdk-bart](https://github.com/Fitbit/sdk-bart)
 - Settings file transfer code from [fitbit-file-transfer-settings](https://github.com/KiezelPay/fitbit-file-transfer-settings)
 
+# Setup
+
+To build this for the old Versa 2, you first need to:
+- `npx create-fitbit-app tmp --sdk-version 4.3.0`
+- `cp tmp/node_modules fitbit-authenticator`
+- `cd fitbit-authenticator && npx fitbit`
+More details: [Getting Started](https://dev.fitbit.com/getting-started/)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ For a list of all changes please click [here](CHANGELOG.md).
 # Setup
 
 To build this for the old Versa 2, you first need to:
+
 - `npx create-fitbit-app tmp --sdk-version 4.3.0`
 - `cp tmp/node_modules fitbit-authenticator`
 - `cd fitbit-authenticator && npx fitbit`
-More details: [Getting Started](https://dev.fitbit.com/getting-started/)
+- `build-and-install`
+
+More details: [FitBit SDK Getting Started](https://dev.fitbit.com/getting-started/)

--- a/app/tokens.js
+++ b/app/tokens.js
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import fs from "fs";
 import {FILE_NAME} from "../common/globals.js";
 import {base32ToUint8Array} from "../common/util.js";
 

--- a/app/tokens.js
+++ b/app/tokens.js
@@ -18,6 +18,7 @@ export function AuthToken() {
 AuthToken.prototype.convertTokensToUint8Array = function() {
   let changed = false;
   for (let i in this.file.data) {
+    if (typeof this.file.data[i] == "undefined") continue;
     if (typeof this.file.data[i]["token"] == "string") {
       this.file.data[i]["token"] = base32ToUint8Array(this.file.data[i]["token"]);
       changed = true;

--- a/common/globals.js
+++ b/common/globals.js
@@ -1,5 +1,5 @@
 export const TOKEN_LIST = "token_list"; //displayed in settings
-export const FILE_NAME = "tokens.json"; //internal token storage
+export const FILE_NAME = "tokens.cbor"; //internal token storage
 export const TOKEN_SECRETS = "token_secrets"; //stored internally (old)
 export const TOKEN_NUM = 10;
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "buildTargets": [
       "meson",
       "higgs",
-      "gemini"
+      "gemini",
+      "mira"
     ],
     "i18n": {
       "en": {


### PR DESCRIPTION
I have an old-ish Versa 2 and your app was one of my primary usecases, until Google bought Fitbit and decided they couldn't be bothered to support 3rd-party apps in Europe anymore 🙄 But it was fairly easy to get it to work again, just needed some minor patches and I have my TOTP codes back 😁